### PR TITLE
fix: overlay position dislocation when resize the window

### DIFF
--- a/src/Overlay.svelte
+++ b/src/Overlay.svelte
@@ -67,16 +67,20 @@
         toggleCombo && document.body.addEventListener('keydown', onKeydown)
         toggleEventListener()
     })
+    
     function toggleEventListener() {
         const listener = enabled ? document.body.addEventListener : document.body.removeEventListener
+        listener?.('resize', resetLinkParams)
         listener?.('mousemove', updateLinkParams)
         listener?.('click', handleClick, true)
     }
+
     function toggleEnabled() {
         enabled = !enabled
         overlayVisible = false
         toggleEventListener()
     }
+
     function onKeydown(event) {
         if (event.repeat || event.key === undefined)
             return
@@ -85,6 +89,7 @@
         if (isCombo)
             toggleEnabled()
     }
+
     function isKeyActive(key, event) {
         switch (key) {
             case 'shift':
@@ -149,13 +154,15 @@
             position.height = rect.height
             linkParams = params
         }
-        else {
-            overlayVisible = false
-            linkParams = {
-                file: '',
-                line: 0,
-                column: 0,
-            }
+        else resetLinkParams()
+    }
+
+    function resetLinkParams() {
+        overlayVisible = false
+        linkParams = {
+            file: '',
+            line: 0,
+            column: 0,
         }
     }
 
@@ -254,7 +261,7 @@
         text-decoration: none;
     }
 
-    .svelte-kit-inspector-container:hover .svelte-kit-inspector-banner {
+    .svelte-kit-inspector-container:hover .svelte-kit-inspector-banner, .svelte-kit-inspector-banner:hover {
         display: block;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ function getInspectorPath() {
   return pluginPath.replace(/\/dist$/, '/src')
 }
 
-function svelteKitInspector(options: VitePluginInspectorOptions = DEFAULT_CONFIG):PluginOption {
+function svelteKitInspector(options: VitePluginInspectorOptions = DEFAULT_CONFIG): PluginOption {
   const inspectorPath = getInspectorPath()
   let serverOptions: ServerOptions | undefined
   const finalOptions = extend(DEFAULT_CONFIG, options)
@@ -81,7 +81,7 @@ function svelteKitInspector(options: VitePluginInspectorOptions = DEFAULT_CONFIG
     async transform(code: string, id: string) {
       const { filename, query } = parseSvelteRequest(id)
       const isTpl = filename.endsWith('.svelte') && query.type !== 'style' && !query.raw
-      if(isTpl){
+      if (isTpl) {
         const mgcStr = new MagicString(code)
         // inject load-kit.js into root sfc
         if (filename.includes('root.svelte')) {


### PR DESCRIPTION
I tried to using the entire document directly to the `targetNode`, But the effect is not ideal.


close #1 